### PR TITLE
fix(security): restrict CORS to specific allowed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,12 @@ SUPABASE_JWT_SECRET=your-jwt-secret  # From Project Settings → API → JWT Sec
 API_KEY=change-this-secret-key-for-production
 BACKEND_API_URL=http://backend:8000
 
+# CORS Configuration (Security)
+# Comma-separated list of allowed origins
+# Development: http://localhost:3000
+# Production: https://your-app.vercel.app,https://your-domain.com
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Redis (auto-configured in Docker, set REDIS_URL in Railway)
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,9 @@ SUPABASE_JWT_SECRET=your_jwt_secret_here
 BACKEND_API_URL=http://localhost:8000
 API_KEY=dev-secret-key
 
+# CORS Configuration (Security)
+ALLOWED_ORIGINS=http://localhost:3000
+
 # Redis Cache
 REDIS_HOST=localhost
 REDIS_PORT=6379

--- a/backend/main.py
+++ b/backend/main.py
@@ -38,13 +38,15 @@ app = FastAPI(
 # Include routers
 app.include_router(auth_router)
 
-# CORS middleware
+# CORS middleware - Restrict to specific origins for security
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLOWED_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 # Request size limit middleware


### PR DESCRIPTION
Fixes #4

Removes dangerous `allow_origins=["*"]` CORS configuration that allowed any malicious website to make authenticated requests.

Changes:
- Restrict CORS to environment-configured origins
- Add `ALLOWED_ORIGINS` environment variable
- Limit allowed methods and headers to required ones only

Security improvement: Prevents CSRF attacks in production