### PR TITLE
ci: add GitHub Secrets to workflow for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
       env:
         DEBUG: "true"
         API_KEY: "test-secret-key"
+        SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+        SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        SUPABASE_JWT_SECRET: ${{ secrets.SUPABASE_JWT_SECRET }}
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+        PINECONE_INDEX_NAME: "codeintel-test"
       run: |
         pytest tests/ -v --cov=services --cov-report=term-missing
     


### PR DESCRIPTION
Fixes #10

Problem:
Backend integration tests require real API credentials (Supabase, OpenAI, Pinecone) but CI/CD environment had no access to these, causing 5 test failures with 'Supabase credentials not configured' errors.

Solution:
Add GitHub Secrets to CI workflow env variables for pytest execution.

Secrets added:
- SUPABASE_URL: Supabase project endpoint
- SUPABASE_ANON_KEY: Supabase anonymous key for auth
- SUPABASE_JWT_SECRET: JWT secret for token verification
- OPENAI_API_KEY: OpenAI API for embeddings
- PINECONE_API_KEY: Pinecone for vector search
- PINECONE_INDEX_NAME: Test index name

Benefits:
- Integration tests run against real Supabase instance 
- JWT authentication flow validated in CI/CD
- API endpoint security verified with actual credentials
- Better test coverage than mocking
- Catches real integration issues before deployment