### PR TITLE
fix(frontend): replace hardcoded localhost with environment variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,12 @@
+# Frontend Environment Variables
+# Copy this to .env.local for local development overrides
+
+# Backend API URL
+# Production: Set in Vercel dashboard (e.g., https://codeintel-backend.railway.app)
+# Development: Defaults to http://localhost:8000 (Docker Compose)
+VITE_API_URL=http://localhost:8000
+
+# Supabase Configuration
+# Get these from your Supabase project settings
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -12,8 +12,7 @@ import { ImpactAnalyzer } from './ImpactAnalyzer'
 import { PerformanceDashboard } from './PerformanceDashboard'
 import { UserNav } from './UserNav'
 import type { Repository } from '../types'
-
-const API_URL = 'http://localhost:8000'
+import { API_URL } from '../config/api'
 
 type RepoTab = 'overview' | 'search' | 'dependencies' | 'insights' | 'impact'
 

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,0 +1,13 @@
+/**
+ * API Configuration
+ * 
+ * Centralizes API URL configuration for all frontend components.
+ * 
+ * - Production: Set VITE_API_URL in Vercel dashboard to Railway backend URL
+ * - Development: Defaults to localhost:8000 (Docker Compose)
+ * - Local dev without Docker: Can override with .env.local
+ */
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+export { API_URL }


### PR DESCRIPTION
## Fixes #5 - Frontend uses hardcoded localhost API URL

### Problem
Frontend had hardcoded `http://localhost:8000` in Dashboard.tsx, causing production deployments to fail when the frontend tried to call localhost instead of the Railway backend URL.

### Solution
- Created centralized API config (`src/config/api.ts`)
- Reads from `VITE_API_URL` environment variable
- Falls back to `localhost:8000` for local development
- Added `.env.example` for documentation

### Testing
- Docker build successful
- TypeScript compilation passed
- No other hardcoded URLs found in codebase

### Files Changed
- `frontend/src/config/api.ts` (new)
- `frontend/src/components/Dashboard.tsx` (updated import)
- `frontend/.env.example` (new)