### PR TITLE
fix(deploy): set buildContext for Railway backend deployment

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,8 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "backend/Dockerfile"
+    "dockerfilePath": "backend/Dockerfile",
+    "buildContext": "backend"
   },
   "deploy": {
     "startCommand": "uvicorn main:app --host 0.0.0.0 --port $PORT",


### PR DESCRIPTION
Problem:
Railway deployment failing with error:
  'failed to compute cache key: "/requirements.txt": not found'

Root Cause:
Railway was building from root directory but Dockerfile references files in backend/ directory (requirements.txt, services/, etc.)

Solution:
Add buildContext field to railway.json to specify backend/ as the build directory.

Changes:
- Add "buildContext": "backend" to railway.json build configuration
- Railway now correctly builds from backend/ directory
- All COPY commands in Dockerfile now resolve correctly