### PR TITLE
feat(frontend): Repo Detail Pages Dark Theme (#35)

### DIFF
--- a/frontend/src/components/DependencyGraph.tsx
+++ b/frontend/src/components/DependencyGraph.tsx
@@ -100,7 +100,6 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
       
       const data = await response.json()
       
-      // Convert to React Flow format
       const flowNodes: Node[] = data.nodes.map((node: any) => {
         const fileName = node.label || node.id.split('/').pop()
         const fullPath = node.id
@@ -145,10 +144,10 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
         source: edge.source,
         target: edge.target,
         animated: false,
-        style: { stroke: '#94a3b8', strokeWidth: 1.5 },
+        style: { stroke: '#4b5563', strokeWidth: 1.5 },
         markerEnd: {
           type: MarkerType.ArrowClosed,
-          color: '#94a3b8',
+          color: '#4b5563',
         },
       }))
       
@@ -172,7 +171,6 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
   const handleNodeClick = useCallback((event: any, node: Node) => {
     setHighlightedNode(node.id)
     
-    // Highlight connected nodes
     const connectedNodeIds = new Set<string>()
     connectedNodeIds.add(node.id)
     
@@ -232,67 +230,67 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
 
   if (loading) {
     return (
-      <div className="card p-12 text-center">
-        <div className="w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mx-auto mb-4" />
-        <p className="text-gray-600">Building dependency graph...</p>
+      <div className="p-12 text-center">
+        <div className="w-16 h-16 border-4 border-blue-500/20 border-t-blue-500 rounded-full animate-spin mx-auto mb-4" />
+        <p className="text-gray-400">Building dependency graph...</p>
       </div>
     )
   }
 
   return (
-    <div className="space-y-6">
-      {/* Metrics + Controls */}
+    <div className="p-6 space-y-6">
+      {/* Metrics */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Total Files</div>
-          <div className="text-3xl font-bold text-gray-900">{allNodes.length}</div>
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Total Files</div>
+          <div className="text-3xl font-bold text-white">{allNodes.length}</div>
         </div>
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Dependencies</div>
-          <div className="text-3xl font-bold text-blue-600">{edges.length}</div>
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Dependencies</div>
+          <div className="text-3xl font-bold text-blue-400">{edges.length}</div>
         </div>
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Avg per File</div>
-          <div className="text-3xl font-bold text-gray-900">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Avg per File</div>
+          <div className="text-3xl font-bold text-white">
             {metrics?.avg_dependencies?.toFixed(1) || 0}
           </div>
         </div>
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Showing</div>
-          <div className="text-3xl font-bold text-green-600">{nodes.length}</div>
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Showing</div>
+          <div className="text-3xl font-bold text-green-400">{nodes.length}</div>
         </div>
       </div>
 
       {/* Filter Controls */}
-      <div className="card p-5">
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
         <div className="flex flex-wrap items-center gap-4">
           <label className="flex items-center gap-2 cursor-pointer">
             <input
               type="checkbox"
               checked={filterCritical}
               onChange={(e) => setFilterCritical(e.target.checked)}
-              className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500"
+              className="w-4 h-4 bg-white/5 border-white/10 rounded focus:ring-2 focus:ring-blue-500"
             />
-            <span className="text-sm text-gray-700">Show only critical files (≥3 deps)</span>
+            <span className="text-sm text-gray-300">Show only critical files (≥3 deps)</span>
           </label>
           
           <div className="flex items-center gap-2">
-            <label className="text-sm text-gray-700">Min dependencies:</label>
+            <label className="text-sm text-gray-300">Min dependencies:</label>
             <input
               type="range"
               min="0"
               max="10"
               value={minDeps}
               onChange={(e) => setMinDeps(Number(e.target.value))}
-              className="w-32"
+              className="w-32 accent-blue-500"
             />
-            <span className="text-sm font-mono text-gray-900">{minDeps}</span>
+            <span className="text-sm font-mono text-white">{minDeps}</span>
           </div>
 
           {highlightedNode && (
             <button
               onClick={resetHighlight}
-              className="text-sm px-3 py-1.5 bg-red-50 text-red-600 rounded hover:bg-red-100 border border-red-200"
+              className="text-sm px-3 py-1.5 bg-red-500/10 text-red-400 rounded-lg hover:bg-red-500/20 border border-red-500/20 transition-colors"
             >
               Clear highlight
             </button>
@@ -302,15 +300,15 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
 
       {/* Most Critical Files */}
       {metrics?.most_critical_files && metrics.most_critical_files.length > 0 && (
-        <div className="card p-5">
-          <h3 className="text-sm font-semibold mb-3 text-gray-900">Most Critical Files</h3>
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <h3 className="text-sm font-semibold mb-3 text-white">Most Critical Files</h3>
           <div className="space-y-2">
             {metrics.most_critical_files.slice(0, 5).map((item: any, idx: number) => (
               <div key={idx} className="flex items-center justify-between text-sm">
-                <span className="font-mono text-gray-700 truncate flex-1">
+                <span className="font-mono text-gray-300 truncate flex-1">
                   {item.file.split('/').slice(-2).join('/')}
                 </span>
-                <span className="badge-danger ml-2">
+                <span className="ml-2 px-2 py-0.5 text-xs bg-red-500/10 text-red-400 border border-red-500/20 rounded">
                   {item.dependents} dependents
                 </span>
               </div>
@@ -320,7 +318,7 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
       )}
 
       {/* Graph Visualization */}
-      <div className="card p-0 overflow-hidden" style={{ height: '700px' }}>
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl overflow-hidden" style={{ height: '700px' }}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -333,39 +331,41 @@ export function DependencyGraph({ repoId, apiUrl, apiKey }: DependencyGraphProps
           minZoom={0.1}
           maxZoom={2}
         >
-          <Background />
-          <Controls />
+          <Background color="#1f1f23" gap={16} />
+          <Controls className="!bg-[#111113] !border-white/10 !rounded-lg [&>button]:!bg-[#111113] [&>button]:!border-white/10 [&>button]:!text-gray-400 [&>button:hover]:!bg-white/10" />
           <MiniMap 
             nodeColor={(node) => {
               const style = node.style as any
               return style?.background || '#6b7280'
             }}
-            maskColor="rgba(0, 0, 0, 0.1)"
+            maskColor="rgba(0, 0, 0, 0.5)"
+            className="!bg-[#111113] !border-white/10"
           />
         </ReactFlow>
       </div>
 
-      <div className="card p-5">
-        <h3 className="text-sm font-semibold mb-3 text-gray-900">Graph Legend</h3>
+      {/* Legend */}
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+        <h3 className="text-sm font-semibold mb-3 text-white">Graph Legend</h3>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs">
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 rounded" style={{ background: '#3776ab' }} />
-            <span className="text-gray-600">Python</span>
+            <span className="text-gray-400">Python</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 rounded" style={{ background: '#3178c6' }} />
-            <span className="text-gray-600">TypeScript</span>
+            <span className="text-gray-400">TypeScript</span>
           </div>
           <div className="flex items-center gap-2">
             <div className="w-4 h-4 rounded" style={{ background: '#f7df1e' }} />
-            <span className="text-gray-600">JavaScript</span>
+            <span className="text-gray-400">JavaScript</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-1 h-4 bg-blue-600" />
-            <span className="text-gray-600">Dependency</span>
+            <div className="w-1 h-4 bg-blue-500" />
+            <span className="text-gray-400">Dependency</span>
           </div>
         </div>
-        <div className="mt-3 pt-3 border-t border-gray-200 text-xs text-gray-600">
+        <div className="mt-3 pt-3 border-t border-white/5 text-xs text-gray-500">
           💡 Click any node to highlight its dependencies • Drag to pan • Scroll to zoom
         </div>
       </div>

--- a/frontend/src/components/ImpactAnalyzer.tsx
+++ b/frontend/src/components/ImpactAnalyzer.tsx
@@ -60,21 +60,21 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
 
   const getRiskColor = (risk: string) => {
     switch (risk) {
-      case 'high': return 'text-red-600 bg-red-50 border-red-200'
-      case 'medium': return 'text-amber-600 bg-amber-50 border-amber-200'
-      case 'low': return 'text-green-600 bg-green-50 border-green-200'
-      default: return 'text-gray-600 bg-gray-50 border-gray-200'
+      case 'high': return 'text-red-400 bg-red-500/10 border-red-500/20'
+      case 'medium': return 'text-yellow-400 bg-yellow-500/10 border-yellow-500/20'
+      case 'low': return 'text-green-400 bg-green-500/10 border-green-500/20'
+      default: return 'text-gray-400 bg-white/5 border-white/10'
     }
   }
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 space-y-6">
       {/* Input Form */}
-      <div className="card p-6">
-        <h3 className="text-base font-semibold mb-4 text-gray-900">Analyze Change Impact</h3>
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+        <h3 className="text-base font-semibold mb-4 text-white">Analyze Change Impact</h3>
         <form onSubmit={analyzeImpact} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-2 text-gray-700">
+            <label className="block text-sm font-medium mb-2 text-gray-300">
               File Path (relative to repository root)
             </label>
             <input
@@ -82,17 +82,17 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
               value={filePath}
               onChange={(e) => setFilePath(e.target.value)}
               placeholder="e.g., src/auth/middleware.py or components/Button.tsx"
-              className="input"
+              className="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder:text-gray-500 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 transition-all"
               disabled={loading}
             />
-            <p className="mt-1.5 text-xs text-gray-500">
+            <p className="mt-2 text-xs text-gray-500">
               Enter the path of the file you want to modify to see its impact
             </p>
           </div>
 
           <button
             type="submit"
-            className="btn-primary"
+            className="px-4 py-2.5 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-medium rounded-lg transition-all disabled:opacity-50"
             disabled={loading}
           >
             {loading ? 'Analyzing...' : 'Analyze Impact'}
@@ -100,7 +100,7 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
         </form>
 
         {error && (
-          <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-md text-sm text-red-700">
+          <div className="mt-4 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-sm text-red-400">
             {error}
           </div>
         )}
@@ -110,26 +110,26 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
       {result && (
         <div className="space-y-6">
           {/* Risk Assessment */}
-          <div className={`card p-6 border-2 ${getRiskColor(result.risk_level)}`}>
+          <div className={`bg-[#0a0a0c] rounded-xl p-5 border-2 ${getRiskColor(result.risk_level)}`}>
             <div className="flex items-center justify-between mb-3">
-              <h3 className="text-lg font-semibold">Risk Assessment</h3>
-              <span className={`px-4 py-1.5 rounded-md font-semibold uppercase text-sm border ${getRiskColor(result.risk_level)}`}>
+              <h3 className="text-lg font-semibold text-white">Risk Assessment</h3>
+              <span className={`px-4 py-1.5 rounded-lg font-semibold uppercase text-sm border ${getRiskColor(result.risk_level)}`}>
                 {result.risk_level} Risk
               </span>
             </div>
-            <p className="text-sm font-mono text-gray-700 mb-4">
+            <p className="text-sm font-mono text-gray-300 mb-4">
               {result.file}
             </p>
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-gray-400">
               {result.impact_summary}
             </p>
           </div>
 
           {/* Impact Overview */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="card p-5">
-              <div className="text-sm text-gray-600 mb-1">Direct Dependencies</div>
-              <div className="text-3xl font-bold text-blue-600">
+            <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+              <div className="text-sm text-gray-400 mb-1">Direct Dependencies</div>
+              <div className="text-3xl font-bold text-blue-400">
                 {result.dependency_count}
               </div>
               <div className="text-xs text-gray-500 mt-1">
@@ -137,9 +137,9 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
               </div>
             </div>
 
-            <div className="card p-5">
-              <div className="text-sm text-gray-600 mb-1">Total Impact</div>
-              <div className="text-3xl font-bold text-amber-600">
+            <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+              <div className="text-sm text-gray-400 mb-1">Total Impact</div>
+              <div className="text-3xl font-bold text-yellow-400">
                 {result.dependent_count}
               </div>
               <div className="text-xs text-gray-500 mt-1">
@@ -147,9 +147,9 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
               </div>
             </div>
 
-            <div className="card p-5">
-              <div className="text-sm text-gray-600 mb-1">Test Files</div>
-              <div className="text-3xl font-bold text-green-600">
+            <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+              <div className="text-sm text-gray-400 mb-1">Test Files</div>
+              <div className="text-3xl font-bold text-green-400">
                 {result.test_files?.length || 0}
               </div>
               <div className="text-xs text-gray-500 mt-1">
@@ -160,16 +160,16 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
 
           {/* Dependencies (What This File Needs) */}
           {result.direct_dependencies && result.direct_dependencies.length > 0 && (
-            <div className="card p-6">
-              <h3 className="text-base font-semibold mb-4 text-gray-900">
+            <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+              <h3 className="text-base font-semibold mb-4 text-white">
                 Dependencies ({result.direct_dependencies.length})
               </h3>
-              <p className="text-sm text-gray-600 mb-3">
+              <p className="text-sm text-gray-400 mb-3">
                 Files this file imports (upstream)
               </p>
               <div className="space-y-1.5">
                 {result.direct_dependencies.map((dep, idx) => (
-                  <div key={idx} className="text-sm font-mono text-gray-700 bg-blue-50 px-3 py-2 rounded">
+                  <div key={idx} className="text-sm font-mono text-gray-300 bg-blue-500/10 border border-blue-500/20 px-3 py-2 rounded-lg">
                     {dep}
                   </div>
                 ))}
@@ -179,16 +179,16 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
 
           {/* Dependents (What Breaks If Changed) */}
           {result.all_dependents && result.all_dependents.length > 0 && (
-            <div className="card p-6">
-              <h3 className="text-base font-semibold mb-4 text-gray-900">
+            <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+              <h3 className="text-base font-semibold mb-4 text-white">
                 Affected Files ({result.all_dependents.length})
               </h3>
-              <p className="text-sm text-gray-600 mb-3">
+              <p className="text-sm text-gray-400 mb-3">
                 Files that would be impacted by changes to this file (downstream)
               </p>
               <div className="space-y-1.5 max-h-96 overflow-y-auto">
                 {result.all_dependents.map((dep, idx) => (
-                  <div key={idx} className="text-sm font-mono text-gray-700 bg-amber-50 px-3 py-2 rounded">
+                  <div key={idx} className="text-sm font-mono text-gray-300 bg-yellow-500/10 border border-yellow-500/20 px-3 py-2 rounded-lg">
                     {dep}
                   </div>
                 ))}
@@ -198,16 +198,16 @@ export function ImpactAnalyzer({ repoId, apiUrl, apiKey }: ImpactAnalyzerProps) 
 
           {/* Test Files */}
           {result.test_files && result.test_files.length > 0 && (
-            <div className="card p-6">
-              <h3 className="text-base font-semibold mb-4 text-gray-900">
+            <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+              <h3 className="text-base font-semibold mb-4 text-white">
                 Related Tests ({result.test_files.length})
               </h3>
-              <p className="text-sm text-gray-600 mb-3">
+              <p className="text-sm text-gray-400 mb-3">
                 Test files that may need updates
               </p>
               <div className="space-y-1.5">
                 {result.test_files.map((test, idx) => (
-                  <div key={idx} className="text-sm font-mono text-gray-700 bg-green-50 px-3 py-2 rounded">
+                  <div key={idx} className="text-sm font-mono text-gray-300 bg-green-500/10 border border-green-500/20 px-3 py-2 rounded-lg">
                     {test}
                   </div>
                 ))}

--- a/frontend/src/components/RepoOverview.tsx
+++ b/frontend/src/components/RepoOverview.tsx
@@ -22,9 +22,8 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
   const [indexing, setIndexing] = useState(false)
   const [progress, setProgress] = useState<IndexProgress | null>(null)
   const wsRef = useRef<WebSocket | null>(null)
-  const completedRef = useRef(false) // Track if indexing completed successfully
+  const completedRef = useRef(false)
 
-  // Cleanup WebSocket on unmount
   useEffect(() => {
     return () => {
       if (wsRef.current) {
@@ -38,7 +37,6 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
     setProgress({ files_processed: 0, functions_indexed: 0, total_files: 0, progress_pct: 0 })
     completedRef.current = false
     
-    // Connect to WebSocket for real-time progress
     const wsUrl = `${WS_URL}/ws/index/${repo.id}?token=${apiKey}`
     
     try {
@@ -81,7 +79,6 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
       }
 
       ws.onclose = () => {
-        // Only fallback if we didn't complete successfully
         if (!completedRef.current) {
           fallbackToHttp()
         }
@@ -93,7 +90,7 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
   }
 
   const fallbackToHttp = async () => {
-    if (completedRef.current) return // Already completed
+    if (completedRef.current) return
     
     toast.loading('Using fallback indexing...', { id: 'reindex' })
     
@@ -122,48 +119,54 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
   }
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 space-y-6">
       {/* Stats Cards */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="card p-6">
-          <div className="text-sm text-gray-600 mb-1">Status</div>
-          <div className="flex items-center gap-2 mt-2">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-2">Status</div>
+          <div className="flex items-center gap-2">
             {repo.status === 'indexed' && (
-              <span className="badge-success text-sm">✓ Indexed</span>
+              <span className="px-2.5 py-1 text-sm font-medium bg-green-500/10 text-green-400 border border-green-500/20 rounded-full">
+                ✓ Indexed
+              </span>
             )}
             {repo.status === 'cloned' && (
-              <span className="badge-success text-sm">✓ Ready</span>
+              <span className="px-2.5 py-1 text-sm font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20 rounded-full">
+                ✓ Ready
+              </span>
             )}
             {repo.status === 'indexing' && (
-              <span className="badge-warning text-sm">🔄 Indexing</span>
+              <span className="px-2.5 py-1 text-sm font-medium bg-yellow-500/10 text-yellow-400 border border-yellow-500/20 rounded-full animate-pulse">
+                🔄 Indexing
+              </span>
             )}
           </div>
         </div>
 
-        <div className="card p-6">
-          <div className="text-sm text-gray-600 mb-1">Functions Indexed</div>
-          <div className="text-3xl font-bold text-blue-600 mt-1">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-2">Functions Indexed</div>
+          <div className="text-3xl font-bold text-blue-400">
             {repo.file_count?.toLocaleString() || 0}
           </div>
         </div>
 
-        <div className="card p-6">
-          <div className="text-sm text-gray-600 mb-1">Branch</div>
-          <div className="text-lg font-mono text-gray-900 mt-2">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-2">Branch</div>
+          <div className="text-lg font-mono text-white">
             {repo.branch}
           </div>
         </div>
       </div>
 
-      {/* Indexing Progress - only show when indexing AND progress exists */}
+      {/* Indexing Progress */}
       {indexing && progress && (
-        <div className="card p-6 border-2 border-blue-500 bg-blue-50">
+        <div className="bg-blue-500/10 border border-blue-500/20 rounded-xl p-5">
           <div className="flex items-center justify-between mb-3">
-            <h3 className="text-base font-semibold text-gray-900">🔄 Indexing in Progress</h3>
-            <span className="text-sm font-mono text-blue-600">{progress.progress_pct}%</span>
+            <h3 className="text-base font-semibold text-white">🔄 Indexing in Progress</h3>
+            <span className="text-sm font-mono text-blue-400">{progress.progress_pct}%</span>
           </div>
           <Progress value={progress.progress_pct} className="h-2" />
-          <div className="flex justify-between text-xs text-gray-600 mt-2">
+          <div className="flex justify-between text-xs text-gray-400 mt-2">
             <span>Files: {progress.files_processed}/{progress.total_files || '?'}</span>
             <span>Functions: {progress.functions_indexed}</span>
           </div>
@@ -171,50 +174,50 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
       )}
 
       {/* Repository Info */}
-      <div className="card p-6 space-y-4">
-        <h3 className="text-base font-semibold text-gray-900">Repository Details</h3>
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5 space-y-4">
+        <h3 className="text-base font-semibold text-white">Repository Details</h3>
         
         <div className="space-y-3 text-sm">
           <div className="flex items-start gap-3">
-            <span className="text-gray-600 w-24">Name:</span>
-            <span className="text-gray-900 font-medium">{repo.name}</span>
+            <span className="text-gray-500 w-24">Name:</span>
+            <span className="text-white font-medium">{repo.name}</span>
           </div>
 
           <div className="flex items-start gap-3">
-            <span className="text-gray-600 w-24">Git URL:</span>
+            <span className="text-gray-500 w-24">Git URL:</span>
             <a 
               href={repo.git_url} 
               target="_blank" 
               rel="noopener noreferrer"
-              className="text-blue-600 hover:underline font-mono text-xs break-all"
+              className="text-blue-400 hover:text-blue-300 font-mono text-xs break-all transition-colors"
             >
               {repo.git_url}
             </a>
           </div>
 
           <div className="flex items-start gap-3">
-            <span className="text-gray-600 w-24">Local Path:</span>
-            <span className="text-gray-700 font-mono text-xs">{repo.local_path}</span>
+            <span className="text-gray-500 w-24">Local Path:</span>
+            <span className="text-gray-300 font-mono text-xs">{repo.local_path}</span>
           </div>
         </div>
       </div>
 
       {/* Actions */}
-      <div className="card p-6">
-        <h3 className="text-base font-semibold text-gray-900 mb-4">Actions</h3>
-        <p className="text-sm text-gray-600 mb-4">
-          Re-indexing uses <strong>incremental mode</strong> - only processes changed files for 100x faster updates!
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+        <h3 className="text-base font-semibold text-white mb-3">Actions</h3>
+        <p className="text-sm text-gray-400 mb-4">
+          Re-indexing uses <span className="text-white font-medium">incremental mode</span> - only processes changed files for 100x faster updates!
         </p>
         <div className="flex gap-3">
           <button
             onClick={handleReindex}
             disabled={indexing}
-            className="btn-primary disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-4 py-2.5 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white text-sm font-medium rounded-lg transition-all disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {indexing ? '🔄 Indexing...' : '🔄 Re-index Repository'}
           </button>
           <button
-            className="btn-secondary"
+            className="px-4 py-2.5 bg-white/5 border border-white/10 text-gray-300 text-sm font-medium rounded-lg hover:bg-white/10 transition-colors"
             onClick={() => toast.info('Delete functionality coming soon')}
           >
             🗑️ Remove
@@ -223,13 +226,13 @@ export function RepoOverview({ repo, onReindex, apiUrl, apiKey }: RepoOverviewPr
       </div>
 
       {/* Quick Guide */}
-      <div className="card p-6 bg-blue-50 border-blue-200">
-        <h3 className="text-base font-semibold text-gray-900 mb-2">💡 Quick Guide</h3>
-        <ul className="text-sm text-gray-700 space-y-2">
-          <li>• <strong>Search</strong> tab - Find code by meaning, not keywords</li>
-          <li>• <strong>Dependencies</strong> tab - Visualize code architecture</li>
-          <li>• <strong>Code Style</strong> tab - Analyze team coding patterns</li>
-          <li>• <strong>Impact</strong> tab - See what breaks when you change a file</li>
+      <div className="bg-gradient-to-br from-blue-500/10 to-purple-500/10 border border-blue-500/20 rounded-xl p-5">
+        <h3 className="text-base font-semibold text-white mb-3">💡 Quick Guide</h3>
+        <ul className="text-sm text-gray-300 space-y-2">
+          <li>• <span className="text-white font-medium">Search</span> tab - Find code by meaning, not keywords</li>
+          <li>• <span className="text-white font-medium">Dependencies</span> tab - Visualize code architecture</li>
+          <li>• <span className="text-white font-medium">Code Style</span> tab - Analyze team coding patterns</li>
+          <li>• <span className="text-white font-medium">Impact</span> tab - See what breaks when you change a file</li>
           <li>• Use with Claude Desktop via MCP for AI-powered code understanding</li>
         </ul>
       </div>

--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -53,9 +53,9 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 space-y-6">
       {/* Search */}
-      <div className="card p-6">
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
         <form onSubmit={handleSearch}>
           <div className="flex gap-3">
             <input
@@ -63,36 +63,36 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="e.g., authentication middleware, React hooks, database queries..."
-              className="input flex-1"
+              className="flex-1 px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder:text-gray-500 focus:outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 transition-all"
               disabled={loading}
               autoFocus
             />
             <button
               type="submit"
-              className="btn-primary px-6"
+              className="px-6 py-3 bg-gradient-to-r from-blue-500 to-blue-600 hover:from-blue-600 hover:to-blue-700 text-white font-medium rounded-xl transition-all disabled:opacity-50"
               disabled={loading}
             >
               {loading ? 'Searching...' : 'Search'}
             </button>
           </div>
-          <p className="mt-2 text-xs text-gray-500">
+          <p className="mt-3 text-xs text-gray-500">
             Powered by semantic embeddings - finds code by meaning, not just keywords
           </p>
         </form>
 
         {searchTime !== null && (
-          <div className="mt-4 pt-4 border-t border-gray-200 flex items-center gap-4 text-sm text-gray-600">
+          <div className="mt-4 pt-4 border-t border-white/5 flex items-center gap-4 text-sm text-gray-400">
             <span>
-              <span className="font-semibold text-gray-900">{results.length}</span> results
+              <span className="font-semibold text-white">{results.length}</span> results
             </span>
-            <span className="text-gray-300">•</span>
+            <span className="text-gray-600">•</span>
             <span>
-              <span className="font-mono font-semibold text-gray-900">{searchTime}ms</span>
+              <span className="font-mono font-semibold text-white">{searchTime}ms</span>
             </span>
             {cached && (
               <>
-                <span className="text-gray-300">•</span>
-                <span className="text-xs bg-green-50 text-green-700 px-2 py-0.5 rounded-md">
+                <span className="text-gray-600">•</span>
+                <span className="text-xs bg-green-500/10 text-green-400 border border-green-500/20 px-2 py-0.5 rounded-md">
                   ⚡ Cached
                 </span>
               </>
@@ -104,15 +104,15 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
       {/* Results */}
       <div className="space-y-4">
         {results.map((result, idx) => (
-          <div key={idx} className="card p-6 hover:shadow-md transition-shadow group">
+          <div key={idx} className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5 hover:border-white/10 transition-all group">
             {/* Header */}
             <div className="flex items-start justify-between mb-4">
               <div className="flex-1">
                 <div className="flex items-center gap-2 mb-1">
-                  <h3 className="font-mono font-semibold text-sm text-gray-900">
+                  <h3 className="font-mono font-semibold text-sm text-white">
                     {result.name}
                   </h3>
-                  <span className="badge-neutral text-[10px] uppercase tracking-wide">
+                  <span className="px-2 py-0.5 text-[10px] uppercase tracking-wide bg-white/5 text-gray-400 border border-white/10 rounded">
                     {result.type.replace('_', ' ')}
                   </span>
                 </div>
@@ -124,7 +124,7 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
               <div className="flex items-center gap-3">
                 <div className="text-right">
                   <div className="text-xs font-mono text-gray-500">Match</div>
-                  <div className="text-sm font-mono font-semibold text-blue-600">
+                  <div className="text-sm font-mono font-semibold text-blue-400">
                     {(result.score * 100).toFixed(0)}%
                   </div>
                 </div>
@@ -132,8 +132,9 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
                   onClick={(e) => {
                     e.stopPropagation()
                     navigator.clipboard.writeText(result.code)
+                    toast.success('Code copied!')
                   }}
-                  className="btn-ghost px-3 py-1.5 opacity-0 group-hover:opacity-100 transition-opacity"
+                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 rounded-lg opacity-0 group-hover:opacity-100 transition-all"
                   title="Copy code"
                 >
                   Copy
@@ -142,7 +143,7 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
             </div>
 
             {/* Code with Syntax Highlighting */}
-            <div className="relative">
+            <div className="relative rounded-lg overflow-hidden">
               <SyntaxHighlighter
                 language={result.language}
                 style={oneDark}
@@ -151,6 +152,7 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
                   borderRadius: '0.5rem',
                   fontSize: '0.75rem',
                   lineHeight: '1.5',
+                  background: '#0d0d0f',
                 }}
                 showLineNumbers
                 startingLineNumber={result.line_start}
@@ -159,7 +161,7 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
               </SyntaxHighlighter>
               
               <div className="absolute top-3 right-3">
-                <span className="badge-neutral text-[10px] font-mono uppercase bg-gray-900/80 backdrop-blur">
+                <span className="px-2 py-0.5 text-[10px] font-mono uppercase bg-black/50 text-gray-400 backdrop-blur rounded">
                   {result.language}
                 </span>
               </div>
@@ -170,8 +172,8 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
               <span className="font-mono">
                 Lines {result.line_start}–{result.line_end}
               </span>
-              <span className="text-gray-300">•</span>
-              <span className="text-gray-400 truncate">
+              <span className="text-gray-600">•</span>
+              <span className="text-gray-500 truncate">
                 {result.file_path}
               </span>
             </div>
@@ -181,12 +183,12 @@ export function SearchPanel({ repoId, apiUrl, apiKey }: SearchPanelProps) {
 
       {/* Empty State */}
       {results.length === 0 && query && !loading && (
-        <div className="card p-16 text-center">
-          <div className="w-20 h-20 mx-auto mb-4 rounded-full bg-gray-100 flex items-center justify-center">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-16 text-center">
+          <div className="w-20 h-20 mx-auto mb-4 rounded-2xl bg-white/5 flex items-center justify-center">
             <span className="text-4xl">🔍</span>
           </div>
-          <h3 className="text-base font-semibold mb-2 text-gray-900">No results found</h3>
-          <p className="text-sm text-gray-600">
+          <h3 className="text-base font-semibold mb-2 text-white">No results found</h3>
+          <p className="text-sm text-gray-400">
             Try a different query or check if the repository is fully indexed
           </p>
         </div>

--- a/frontend/src/components/StyleInsights.tsx
+++ b/frontend/src/components/StyleInsights.tsx
@@ -21,7 +21,6 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
         headers: { 'Authorization': `Bearer ${apiKey}` }
       })
       const result = await response.json()
-      console.log('Style data:', result)
       setData(result)
     } catch (error) {
       console.error('Error loading style data:', error)
@@ -32,9 +31,9 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
 
   if (loading) {
     return (
-      <div className="card p-12 text-center">
-        <div className="w-16 h-16 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mx-auto mb-4" />
-        <p className="text-gray-600">Analyzing code style patterns...</p>
+      <div className="p-12 text-center">
+        <div className="w-16 h-16 border-4 border-blue-500/20 border-t-blue-500 rounded-full animate-spin mx-auto mb-4" />
+        <p className="text-gray-400">Analyzing code style patterns...</p>
       </div>
     )
   }
@@ -42,33 +41,33 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
   if (!data) return null
 
   return (
-    <div className="space-y-6">
+    <div className="p-6 space-y-6">
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Files Analyzed</div>
-          <div className="text-3xl font-bold text-gray-900">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Files Analyzed</div>
+          <div className="text-3xl font-bold text-white">
             {data.summary?.total_files_analyzed || 0}
           </div>
         </div>
 
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Functions</div>
-          <div className="text-3xl font-bold text-blue-600">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Functions</div>
+          <div className="text-3xl font-bold text-blue-400">
             {data.summary?.total_functions || 0}
           </div>
         </div>
 
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Async Adoption</div>
-          <div className="text-3xl font-bold text-green-600">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Async Adoption</div>
+          <div className="text-3xl font-bold text-green-400">
             {data.summary?.async_adoption || '0%'}
           </div>
         </div>
 
-        <div className="card p-5">
-          <div className="text-sm text-gray-600 mb-1">Type Hints</div>
-          <div className="text-3xl font-bold text-purple-600">
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <div className="text-sm text-gray-400 mb-1">Type Hints</div>
+          <div className="text-3xl font-bold text-purple-400">
             {data.summary?.type_hints_usage || '0%'}
           </div>
         </div>
@@ -76,20 +75,20 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
 
       {/* Naming Conventions */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div className="card p-6">
-          <h3 className="text-base font-semibold mb-4 text-gray-900">Function Naming</h3>
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <h3 className="text-base font-semibold mb-4 text-white">Function Naming</h3>
           <div className="space-y-3">
             {data.naming_conventions?.functions && 
               Object.entries(data.naming_conventions.functions).map(([convention, info]: any) => (
                 <div key={convention} className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <code className="text-sm bg-gray-100 px-2 py-1 rounded text-gray-700">
+                    <code className="text-sm bg-white/5 px-2 py-1 rounded text-gray-300 border border-white/5">
                       {convention}
                     </code>
                   </div>
                   <div className="flex items-center gap-3">
-                    <span className="text-sm text-gray-600">{info.count}</span>
-                    <span className="text-sm font-semibold text-blue-600 min-w-[50px] text-right">
+                    <span className="text-sm text-gray-500">{info.count}</span>
+                    <span className="text-sm font-semibold text-blue-400 min-w-[50px] text-right">
                       {info.percentage}
                     </span>
                   </div>
@@ -99,20 +98,20 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
           </div>
         </div>
 
-        <div className="card p-6">
-          <h3 className="text-base font-semibold mb-4 text-gray-900">Class Naming</h3>
+        <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+          <h3 className="text-base font-semibold mb-4 text-white">Class Naming</h3>
           <div className="space-y-3">
             {data.naming_conventions?.classes && 
               Object.entries(data.naming_conventions.classes).map(([convention, info]: any) => (
                 <div key={convention} className="flex items-center justify-between">
                   <div className="flex items-center gap-3">
-                    <code className="text-sm bg-gray-100 px-2 py-1 rounded text-gray-700">
+                    <code className="text-sm bg-white/5 px-2 py-1 rounded text-gray-300 border border-white/5">
                       {convention}
                     </code>
                   </div>
                   <div className="flex items-center gap-3">
-                    <span className="text-sm text-gray-600">{info.count}</span>
-                    <span className="text-sm font-semibold text-blue-600 min-w-[50px] text-right">
+                    <span className="text-sm text-gray-500">{info.count}</span>
+                    <span className="text-sm font-semibold text-blue-400 min-w-[50px] text-right">
                       {info.percentage}
                     </span>
                   </div>
@@ -124,39 +123,39 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
       </div>
 
       {/* Top Imports */}
-      <div className="card p-6">
-        <h3 className="text-base font-semibold mb-4 text-gray-900">Most Common Imports</h3>
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+        <h3 className="text-base font-semibold mb-4 text-white">Most Common Imports</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {data.top_imports?.slice(0, 10).map((item: any, idx: number) => (
             <div key={idx} className="flex items-center justify-between text-sm">
-              <code className="text-gray-700 bg-gray-50 px-2 py-1 rounded truncate flex-1">
+              <code className="text-gray-300 bg-white/5 border border-white/5 px-2 py-1 rounded truncate flex-1">
                 {item.module}
               </code>
-              <span className="ml-3 text-gray-600 font-mono">{item.count}×</span>
+              <span className="ml-3 text-gray-500 font-mono">{item.count}×</span>
             </div>
           ))}
         </div>
       </div>
 
       {/* Patterns */}
-      <div className="card p-6">
-        <h3 className="text-base font-semibold mb-4 text-gray-900">Code Patterns</h3>
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+        <h3 className="text-base font-semibold mb-4 text-white">Code Patterns</h3>
         <div className="space-y-3 text-sm">
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded">
-            <span className="text-gray-700">Async/Await Usage</span>
+          <div className="flex items-center justify-between p-3 bg-white/5 rounded-lg border border-white/5">
+            <span className="text-gray-300">Async/Await Usage</span>
             <div className="flex items-center gap-2">
-              <span className="text-gray-600">{data.patterns?.async_usage}</span>
-              <span className="badge-success">
+              <span className="text-gray-500">{data.patterns?.async_usage}</span>
+              <span className="px-2 py-0.5 text-xs bg-green-500/10 text-green-400 border border-green-500/20 rounded">
                 {data.patterns?.async_percentage?.toFixed(0)}%
               </span>
             </div>
           </div>
 
-          <div className="flex items-center justify-between p-3 bg-gray-50 rounded">
-            <span className="text-gray-700">Type Annotations</span>
+          <div className="flex items-center justify-between p-3 bg-white/5 rounded-lg border border-white/5">
+            <span className="text-gray-300">Type Annotations</span>
             <div className="flex items-center gap-2">
-              <span className="text-gray-600">{data.patterns?.type_annotations}</span>
-              <span className="badge-success">
+              <span className="text-gray-500">{data.patterns?.type_annotations}</span>
+              <span className="px-2 py-0.5 text-xs bg-green-500/10 text-green-400 border border-green-500/20 rounded">
                 {data.patterns?.typed_percentage?.toFixed(0)}%
               </span>
             </div>
@@ -165,20 +164,20 @@ export function StyleInsights({ repoId, apiUrl, apiKey }: StyleInsightsProps) {
       </div>
 
       {/* Language Distribution */}
-      <div className="card p-6">
-        <h3 className="text-base font-semibold mb-4 text-gray-900">Language Distribution</h3>
-        <div className="space-y-2">
+      <div className="bg-[#0a0a0c] border border-white/5 rounded-xl p-5">
+        <h3 className="text-base font-semibold mb-4 text-white">Language Distribution</h3>
+        <div className="space-y-3">
           {data.language_distribution && 
             Object.entries(data.language_distribution).map(([lang, info]: any) => (
               <div key={lang} className="flex items-center gap-3">
-                <span className="text-sm text-gray-700 w-24 capitalize">{lang}</span>
-                <div className="flex-1 bg-gray-200 rounded-full h-2">
+                <span className="text-sm text-gray-300 w-24 capitalize">{lang}</span>
+                <div className="flex-1 bg-white/5 rounded-full h-2">
                   <div 
-                    className="bg-blue-600 h-2 rounded-full transition-all"
+                    className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all"
                     style={{ width: info.percentage }}
                   />
                 </div>
-                <span className="text-sm text-gray-600 w-16 text-right">{info.percentage}</span>
+                <span className="text-sm text-gray-400 w-16 text-right">{info.percentage}</span>
               </div>
             ))
           }


### PR DESCRIPTION
## Summary

Complete dark theme conversion for all repository detail pages, ensuring consistency with dashboard design.

## Changes

- **RepoOverview.tsx** - Dark stat cards, gradient Quick Guide
- **SearchPanel.tsx** - Dark search input, dark result cards
- **DependencyGraph.tsx** - Dark stats, styled ReactFlow controls
- **StyleInsights.tsx** - Dark naming convention cards, imports, patterns
- **ImpactAnalyzer.tsx** - Dark form, color-coded risk badges

## Design System

- Background: `#0a0a0c` (cards), `#111113` (outer)
- Borders: `border-white/5`
- Text: white primary, gray-400 secondary
- Accents: blue-400, green-400, purple-400

## Screenshots

<img width="1800" height="927" alt="image" src="https://github.com/user-attachments/assets/fd78098a-b379-4f22-acc4-097113721053" />


Closes #35