### PR TITLE
docs: Fix repository URLs to point to OpenCodeIntel org

### DIFF
--- a/DOCKER_QUICKSTART.md
+++ b/DOCKER_QUICKSTART.md
@@ -11,8 +11,8 @@ Get CodeIntel running locally with Docker in 5 minutes.
 ## Step 1: Clone & Navigate
 
 ```bash
-git clone https://github.com/DevanshuNEU/v1--codeintel.git
-cd v1--codeintel
+git clone https://github.com/OpenCodeIntel/opencodeintel.git
+cd opencodeintel
 ```
 
 ## Step 2: Configure Environment
@@ -192,5 +192,5 @@ Full deployment guide: `DEPLOYMENT.md`
 
 **Need help?** 
 - 📖 Check `DOCKER_TROUBLESHOOTING.md`
-- 🐛 Open an issue: https://github.com/DevanshuNEU/v1--codeintel/issues
+- 🐛 Open an issue: https://github.com/OpenCodeIntel/opencodeintel/issues
 - 📝 See full docs: `README.md`

--- a/DOCKER_TROUBLESHOOTING.md
+++ b/DOCKER_TROUBLESHOOTING.md
@@ -276,7 +276,7 @@ docker compose exec backend curl http://backend:8000/health
 
 ## Still Having Issues?
 
-1. Check GitHub Issues: https://github.com/DevanshuNEU/v1--codeintel/issues
+1. Check GitHub Issues: https://github.com/OpenCodeIntel/opencodeintel/issues
 2. Run verification script: `./scripts/verify-setup.sh`
 3. Check DEPLOYMENT.md for step-by-step instructions
 4. Make sure Docker Desktop has enough resources (Settings → Resources)

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Understand team patterns: naming conventions (camelCase vs snake_case), async ad
 
 ```bash
 # 1. Clone repo
-git clone https://github.com/DevanshuNEU/v1--codeintel.git
-cd v1--codeintel
+git clone https://github.com/OpenCodeIntel/opencodeintel.git
+cd opencodeintel
 
 # 2. Configure environment
 cp .env.example .env


### PR DESCRIPTION
## Summary
Fixes incorrect repository URLs across documentation files.

## Problem
Documentation was pointing to old repository URLs:
- `https://github.com/DevanshuNEU/v1--codeintel.git`
- Directory name `v1--codeintel`

This causes confusion for new users trying to clone and set up the project.

## Changes
Updated all URLs to point to the official OpenCodeIntel organization:

| File | Change |
|------|--------|
| `README.md` | Clone URL + directory name |
| `DOCKER_QUICKSTART.md` | Clone URL + directory name + issues link |
| `DOCKER_TROUBLESHOOTING.md` | Issues link |

## New URLs
- Clone: `https://github.com/OpenCodeIntel/opencodeintel.git`
- Issues: `https://github.com/OpenCodeIntel/opencodeintel/issues`
- Directory: `opencodeintel`

## Verification
```bash
grep -rn "v1--codeintel" --include="*.md"
# Returns empty (no old URLs remaining)
```

Closes #63