### PR TITLE
fix: durable repo-state v0.1: lazy re-clone + stuck-job recovery (#311)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -44,6 +44,10 @@ from routes.ws_repos import websocket_repo_indexing
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     validate_environment()
+    # Any repo left 'indexing' at boot is orphaned (indexing runs in-process; a restart
+    # kills it). Reset so the user can retry instead of seeing an eternal spinner. (#311)
+    from services.supabase_service import get_supabase_service
+    get_supabase_service().reset_stuck_indexing_jobs()
     await load_demo_repos()
     yield
     # Shutdown (cleanup if needed)

--- a/backend/migrations/003_add_indexing_started_at.sql
+++ b/backend/migrations/003_add_indexing_started_at.sql
@@ -1,0 +1,11 @@
+-- Durable repo-state v0.1 (issue #311)
+-- Records when a repo entered the 'indexing' state so the stuck-job reaper can tell a
+-- live job from an orphaned one (process died mid-index, leaving status='indexing' forever).
+
+ALTER TABLE repositories
+    ADD COLUMN IF NOT EXISTS indexing_started_at TIMESTAMPTZ;
+
+-- Partial index: the reaper and the steal-on-retry path only ever scan rows currently indexing.
+CREATE INDEX IF NOT EXISTS idx_repositories_indexing_started_at
+    ON repositories(indexing_started_at)
+    WHERE status = 'indexing';

--- a/backend/routes/analysis.py
+++ b/backend/routes/analysis.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 from dependencies import (
     dependency_analyzer, style_analyzer, dna_extractor,
-    get_repo_or_404
+    get_repo_or_404, repo_manager
 )
 from services.input_validator import InputValidator
 from middleware.auth import require_auth, AuthContext
@@ -35,6 +35,7 @@ async def get_dependency_graph(
                 return {**cached_graph, "cached": True}
 
         logger.info("Building fresh dependency graph", repo_id=repo_id, include_paths=repo.get("include_paths"))
+        await repo_manager.ensure_clone(repo)
         graph_data = dependency_analyzer.build_dependency_graph(repo["local_path"], include_paths=repo.get("include_paths"))
         dependency_analyzer.save_to_cache(repo_id, graph_data)
 
@@ -57,11 +58,14 @@ async def analyze_impact(
     try:
         repo = get_repo_or_404(repo_id, auth.user_id)
 
+        # Validate user input BEFORE any expensive/external work (re-clone). Reject traversal first.
         valid_path, path_error = InputValidator.validate_file_path(
             request.file_path, repo["local_path"]
         )
         if not valid_path:
             raise HTTPException(status_code=400, detail=f"Invalid file path: {path_error}")
+
+        await repo_manager.ensure_clone(repo)
 
         graph_data = dependency_analyzer.load_from_cache(repo_id)
         if not graph_data:
@@ -96,6 +100,7 @@ async def get_repository_insights(
         graph_data = dependency_analyzer.load_from_cache(repo_id)
         if not graph_data:
             logger.info("Building dependency graph for insights", repo_id=repo_id)
+            await repo_manager.ensure_clone(repo)
             graph_data = dependency_analyzer.build_dependency_graph(repo["local_path"], include_paths=repo.get("include_paths"))
             dependency_analyzer.save_to_cache(repo_id, graph_data)
 
@@ -134,6 +139,7 @@ async def get_style_analysis(
             return {**cached_style, "cached": True}
 
         logger.info("Analyzing code style", repo_id=repo_id)
+        await repo_manager.ensure_clone(repo)
         style_data = style_analyzer.analyze_repository_style(repo["local_path"], include_paths=repo.get("include_paths"))
         style_analyzer.save_to_cache(repo_id, style_data)
 
@@ -178,6 +184,7 @@ async def get_codebase_dna(
         logger.info("Extracting codebase DNA", repo_id=repo_id)
         metrics.increment("dna_extractions")
 
+        await repo_manager.ensure_clone(repo)
         dna = dna_extractor.extract_dna(repo["local_path"], repo_id, include_paths=repo.get("include_paths"))
         dna_extractor.save_to_cache(repo_id, dna)
 

--- a/backend/routes/repos.py
+++ b/backend/routes/repos.py
@@ -470,10 +470,9 @@ async def get_repo_directories(
     directories to index instead of the entire repo.
     """
     repo = get_repo_or_404(repo_id, auth.user_id)
+    # Re-clone if the container was redeployed and wiped the working tree (#311).
+    await repo_manager.ensure_clone(repo)
     local_path = Path(repo["local_path"])
-
-    if not local_path.exists():
-        raise HTTPException(status_code=404, detail="Repo not cloned yet")
 
     dirs = await asyncio.to_thread(_scan_directories, local_path)
 
@@ -501,7 +500,9 @@ async def index_repository(
     
     try:
         repo = get_repo_or_404(repo_id, user_id)
-        
+        # Re-clone if the container was redeployed and wiped the working tree (#311).
+        await repo_manager.ensure_clone(repo)
+
         # Re-check size limits before indexing (in case tier changed or repo updated)
         analysis = repo_validator.analyze_repo(repo["local_path"])
         
@@ -765,10 +766,13 @@ async def index_repository_async(
     
     try:
         repo = get_repo_or_404(repo_id, user_id)
-        
+        # Re-clone before the size-check (which reads the working tree) so a redeployed
+        # container rehydrates here, before the 202, rather than failing the gate (#311).
+        await repo_manager.ensure_clone(repo)
+
         # Re-check size limits
         analysis = repo_validator.analyze_repo(repo["local_path"])
-        
+
         if not analysis.success:
             raise HTTPException(
                 status_code=500,
@@ -867,7 +871,15 @@ async def websocket_index(websocket: WebSocket, repo_id: str):
     if not repo:
         await websocket.close(code=4004, reason="Repository not found")
         return
-    
+
+    # Re-clone if the container was redeployed and wiped the working tree (#311).
+    try:
+        await repo_manager.ensure_clone(repo)
+    except Exception as e:
+        logger.error("Re-clone failed for websocket indexing", repo_id=repo_id, error=str(e))
+        await websocket.close(code=4005, reason="Repository clone unavailable")
+        return
+
     # Check size limits before WebSocket indexing
     analysis = repo_validator.analyze_repo(repo["local_path"])
     

--- a/backend/services/repo_manager.py
+++ b/backend/services/repo_manager.py
@@ -209,9 +209,12 @@ class RepositoryManager:
         tmp = self.repos_dir / f".{repo_id}.tmp.{uuid.uuid4().hex}"
         try:
             git.Repo.clone_from(git_url, tmp, branch=branch, depth=1)
-            # Clear any leftover partial dir before the atomic swap.
+            # Clear any leftover partial dir before the atomic swap. Do NOT ignore errors here:
+            # a failed removal must surface (the outer except re-raises it, and ensure_clone wraps
+            # it into a logged RepoCloneError) rather than letting us rename onto a dir we could
+            # not clean, which would fail later with a more confusing error.
             if canonical.exists():
-                shutil.rmtree(canonical, ignore_errors=True)
+                shutil.rmtree(canonical)
             os.rename(tmp, canonical)  # atomic on the same filesystem
         except Exception:
             if tmp.exists():

--- a/backend/services/repo_manager.py
+++ b/backend/services/repo_manager.py
@@ -2,12 +2,40 @@
 Repository Manager (Supabase Edition)
 Handles repository CRUD operations with PostgreSQL via Supabase
 """
+import asyncio
+import os
+import shutil
 import uuid
-from typing import List, Optional
+from typing import Dict, List, Optional
 import git
 from pathlib import Path
+from fastapi import HTTPException
 from services.supabase_service import get_supabase_service
 from services.observability import logger, metrics
+
+
+class RepoCloneError(HTTPException):
+    """Repo working tree is missing and could not be restored from its git remote.
+
+    Subclasses HTTPException so it surfaces as an actionable 503 (handlers already re-raise
+    HTTPException) instead of an opaque 500. UX matters here: a redeploy is invisible to the
+    user, so the message has to tell them what to actually do. (#311)
+    """
+
+    def __init__(self, repo_id: str, reason: str = ""):
+        super().__init__(
+            status_code=503,
+            detail={
+                "error": "REPO_UNAVAILABLE",
+                "repo_id": repo_id,
+                "message": (
+                    "Repository source files are temporarily unavailable and could not be "
+                    "restored from the git remote. Private repositories are not yet supported "
+                    "for re-sync; for public repos, please retry shortly."
+                ),
+            },
+        )
+        self.reason = reason
 
 
 class RepositoryManager:
@@ -17,7 +45,11 @@ class RepositoryManager:
         self.repos_dir = Path("./repos")
         self.repos_dir.mkdir(exist_ok=True)
         self.db = get_supabase_service()
-        
+
+        # Per-repo locks so two concurrent ops on the same missing clone don't both clone.
+        # Single uvicorn worker means an in-process lock is sufficient here.
+        self._clone_locks: Dict[str, asyncio.Lock] = {}
+
         # Discover and sync existing repositories on startup
         self._sync_existing_repos()
     
@@ -126,10 +158,66 @@ class RepositoryManager:
         except Exception as e:
             # Cleanup on failure
             if local_path.exists():
-                import shutil
                 shutil.rmtree(local_path)
             raise Exception(f"Failed to clone repository: {str(e)}")
-    
+
+    async def ensure_clone(self, repo: dict) -> str:
+        """Guarantee the working tree exists on disk, lazily re-cloning from git_url if needed.
+
+        Railway redeploys wipe ./repos (ephemeral disk) but Pinecone/Supabase survive, so
+        local_path is a cache hint, not source of truth -- the git remote is. On a warm hit
+        this is a sub-millisecond stat with no behavior change; on a miss it re-clones.
+        Returns the canonical local path and refreshes repo['local_path'] in place.
+        """
+        repo_id = repo["id"]
+        canonical = self.repos_dir / repo_id
+
+        # Warm path: clone present. No re-clone, no event-loop work.
+        if (canonical / ".git").exists():
+            repo["local_path"] = str(canonical)
+            return str(canonical)
+
+        git_url = repo.get("git_url")
+        if not git_url or git_url == "unknown":
+            raise RepoCloneError(repo_id, "no git_url on record")
+        branch = repo.get("branch") or "main"
+
+        lock = self._clone_locks.setdefault(repo_id, asyncio.Lock())
+        async with lock:
+            # Another coroutine may have cloned while we waited for the lock.
+            if not (canonical / ".git").exists():
+                try:
+                    await asyncio.to_thread(self._clone_into_place, repo_id, git_url, branch, canonical)
+                except Exception as e:
+                    # Private repo (no creds on a fresh container), network failure, deleted
+                    # remote: surface as an actionable 503, not an opaque 500.
+                    logger.error("Re-clone failed", repo_id=repo_id, git_url=git_url, error=str(e))
+                    raise RepoCloneError(repo_id, str(e)) from e
+                logger.info("Re-cloned repo on demand (cache miss)", repo_id=repo_id, git_url=git_url)
+                metrics.increment("repos_recloned")
+
+        repo["local_path"] = str(canonical)
+        return str(canonical)
+
+    def _clone_into_place(self, repo_id: str, git_url: str, branch: str, canonical: Path) -> None:
+        """Clone into a temp dir then atomically rename into the canonical path.
+
+        The rename is the correctness guarantee: a crashed or concurrent clone never leaves a
+        half-populated canonical dir for a reader to trip over. Runs in a worker thread (git is
+        blocking I/O); never call directly on the event loop.
+        """
+        tmp = self.repos_dir / f".{repo_id}.tmp.{uuid.uuid4().hex}"
+        try:
+            git.Repo.clone_from(git_url, tmp, branch=branch, depth=1)
+            # Clear any leftover partial dir before the atomic swap.
+            if canonical.exists():
+                shutil.rmtree(canonical, ignore_errors=True)
+            os.rename(tmp, canonical)  # atomic on the same filesystem
+        except Exception:
+            if tmp.exists():
+                shutil.rmtree(tmp, ignore_errors=True)
+            raise
+
     def update_status(self, repo_id: str, status: str):
         """Update repository status"""
         self.db.update_repository_status(repo_id, status)
@@ -158,8 +246,6 @@ class RepositoryManager:
     
     def delete_repo(self, repo_id: str) -> bool:
         """Delete repository and clean up local files"""
-        import shutil
-        
         repo = self.get_repo(repo_id)
         if not repo:
             return False

--- a/backend/services/supabase_service.py
+++ b/backend/services/supabase_service.py
@@ -100,12 +100,13 @@ class SupabaseService:
         try:
             self.client.table("repositories").update(updates).eq("id", repo_id).execute()
         except Exception as e:
-            # Degrade gracefully if migration 003 (indexing_started_at) hasn't been applied yet:
-            # retry the status update without the new column instead of failing the index.
-            if "indexing_started_at" not in updates:
+            # Only swallow the specific case where migration 003 (indexing_started_at) has not been
+            # applied yet -- detected by the column name appearing in the DB error. Any other error
+            # (network, constraint, etc.) must re-raise so a real failure isn't masked by the retry.
+            if "indexing_started_at" not in updates or "indexing_started_at" not in str(e):
                 raise
             logger.warning(
-                "Status update with indexing_started_at failed; retrying without it (apply migration 003)",
+                "indexing_started_at column missing; retrying status update without it (apply migration 003)",
                 repo_id=repo_id, error=str(e),
             )
             self.client.table("repositories").update({"status": status}).eq("id", repo_id).execute()
@@ -120,6 +121,11 @@ class SupabaseService:
         -- or with no start stamp at all (legacy/pre-migration) -- is treated as orphaned and
         re-claimed, so a crashed job never permanently blocks retry.
         """
+        # cutoff is the staleness threshold for stealing an orphaned 'indexing' lock, derived from
+        # STUCK_INDEXING_THRESHOLD_MINUTES and a SERVER-CONTROLLED datetime.utcnow(). It is never
+        # user input, so interpolating it into the PostgREST .or_ filter string is safe. If any
+        # user-supplied value is ever introduced into this filter, parameterize it via the SDK
+        # (do not f-string it) to avoid filter-injection.
         cutoff = (datetime.utcnow() - timedelta(minutes=STUCK_INDEXING_THRESHOLD_MINUTES)).isoformat()
         try:
             result = self.client.table("repositories").update(
@@ -128,10 +134,12 @@ class SupabaseService:
                 f"status.neq.indexing,indexing_started_at.is.null,indexing_started_at.lt.{cutoff}"
             ).execute()
         except Exception as e:
-            # Degrade gracefully if migration 003 hasn't been applied yet: fall back to the
-            # original atomic compare-and-set (no steal-on-stale) so indexing still works.
+            # Only fall back when migration 003 (indexing_started_at) is missing -- detected by the
+            # column name in the DB error. Re-raise anything else so a real failure isn't masked.
+            if "indexing_started_at" not in str(e):
+                raise
             logger.warning(
-                "try_set_indexing steal path failed; falling back to basic CAS (apply migration 003)",
+                "indexing_started_at column missing; falling back to basic CAS (apply migration 003)",
                 repo_id=repo_id, error=str(e),
             )
             result = self.client.table("repositories").update(

--- a/backend/services/supabase_service.py
+++ b/backend/services/supabase_service.py
@@ -4,11 +4,15 @@ Handles all database operations for CodeIntel
 """
 import os
 from typing import Dict, List, Optional
-from datetime import datetime
+from datetime import datetime, timedelta
 from supabase import create_client, Client, ClientOptions
 import uuid
 
 from services.observability import logger
+
+# A repo stuck in 'indexing' longer than this is treated as orphaned (its indexer
+# process died) and may be re-claimed on retry. The startup sweep is unconditional.
+STUCK_INDEXING_THRESHOLD_MINUTES = 30
 
 
 class SupabaseService:
@@ -87,23 +91,70 @@ class SupabaseService:
         return result.data[0] if result.data else None
     
     def update_repository_status(self, repo_id: str, status: str) -> None:
-        """Update repository status"""
-        self.client.table("repositories").update({"status": status}).eq("id", repo_id).execute()
-    
+        """Update repository status. Transitioning to 'indexing' stamps indexing_started_at
+        so the stuck-job reaper has a clock to measure against, regardless of which code path
+        started the job."""
+        updates: Dict = {"status": status}
+        if status == "indexing":
+            updates["indexing_started_at"] = datetime.utcnow().isoformat()
+        try:
+            self.client.table("repositories").update(updates).eq("id", repo_id).execute()
+        except Exception as e:
+            # Degrade gracefully if migration 003 (indexing_started_at) hasn't been applied yet:
+            # retry the status update without the new column instead of failing the index.
+            if "indexing_started_at" not in updates:
+                raise
+            logger.warning(
+                "Status update with indexing_started_at failed; retrying without it (apply migration 003)",
+                repo_id=repo_id, error=str(e),
+            )
+            self.client.table("repositories").update({"status": status}).eq("id", repo_id).execute()
+
     def try_set_indexing_status(self, repo_id: str) -> bool:
         """
-        Atomically set status to 'indexing' only if not already indexing.
-        
-        Returns True if status was set, False if repo was already indexing.
-        This prevents TOCTOU race conditions where two requests could both
-        see status != 'indexing' and both start indexing.
+        Atomically set status to 'indexing' only if not already actively indexing.
+
+        Returns True if status was set, False if a fresh indexing job already owns the repo.
+        This prevents TOCTOU race conditions where two requests both see status != 'indexing'
+        and both start indexing. A row stuck in 'indexing' past the threshold (its process died)
+        -- or with no start stamp at all (legacy/pre-migration) -- is treated as orphaned and
+        re-claimed, so a crashed job never permanently blocks retry.
+        """
+        cutoff = (datetime.utcnow() - timedelta(minutes=STUCK_INDEXING_THRESHOLD_MINUTES)).isoformat()
+        try:
+            result = self.client.table("repositories").update(
+                {"status": "indexing", "indexing_started_at": datetime.utcnow().isoformat()}
+            ).eq("id", repo_id).or_(
+                f"status.neq.indexing,indexing_started_at.is.null,indexing_started_at.lt.{cutoff}"
+            ).execute()
+        except Exception as e:
+            # Degrade gracefully if migration 003 hasn't been applied yet: fall back to the
+            # original atomic compare-and-set (no steal-on-stale) so indexing still works.
+            logger.warning(
+                "try_set_indexing steal path failed; falling back to basic CAS (apply migration 003)",
+                repo_id=repo_id, error=str(e),
+            )
+            result = self.client.table("repositories").update(
+                {"status": "indexing"}
+            ).eq("id", repo_id).neq("status", "indexing").execute()
+
+        # If result.data is empty, no rows matched (a fresh indexing job owns it)
+        return bool(result.data)
+
+    def reset_stuck_indexing_jobs(self) -> int:
+        """Reset every repo left in 'indexing' to 'error' so the user can retry.
+
+        Called once on startup: indexing runs in-process (BackgroundTasks / WebSocket), so a
+        restart kills any in-flight job and every 'indexing' row at boot is by definition
+        orphaned. Returns the number of rows reset.
         """
         result = self.client.table("repositories").update(
-            {"status": "indexing"}
-        ).eq("id", repo_id).neq("status", "indexing").execute()
-        
-        # If result.data is empty, no rows matched (already indexing)
-        return bool(result.data)
+            {"status": "error"}
+        ).eq("status", "indexing").execute()
+        count = len(result.data) if result.data else 0
+        if count:
+            logger.warning("Reset orphaned indexing jobs on startup", count=count)
+        return count
     
     def update_file_count(self, repo_id: str, count: int) -> None:
         """Update repository file count"""

--- a/backend/tests/test_durable_repo_state.py
+++ b/backend/tests/test_durable_repo_state.py
@@ -169,13 +169,31 @@ class TestStuckJobRecovery:
         """Steal path errors without the column -> fall back to the original atomic CAS."""
         svc = self._service()
         eq_chain = svc.client.table.return_value.update.return_value.eq.return_value
-        eq_chain.or_.return_value.execute.side_effect = Exception("PGRST204 column missing")
+        eq_chain.or_.return_value.execute.side_effect = Exception(
+            "PGRST204 Could not find the 'indexing_started_at' column in schema cache"
+        )
         fallback = MagicMock()
         fallback.data = [{"id": "r1"}]
         eq_chain.neq.return_value.execute.return_value = fallback
 
         assert svc.try_set_indexing_status("r1") is True
         eq_chain.neq.assert_called_once_with("status", "indexing")
+
+    def test_update_status_reraises_unrelated_error(self):
+        """A non-migration error must NOT be masked by the missing-column fallback."""
+        svc = self._service()
+        chain = svc.client.table.return_value.update.return_value.eq.return_value
+        chain.execute.side_effect = Exception("connection reset by peer")
+        with pytest.raises(Exception, match="connection reset"):
+            svc.update_repository_status("r1", "indexing")
+
+    def test_try_set_indexing_reraises_unrelated_error(self):
+        """A non-migration error must NOT trigger the basic-CAS fallback."""
+        svc = self._service()
+        eq_chain = svc.client.table.return_value.update.return_value.eq.return_value
+        eq_chain.or_.return_value.execute.side_effect = Exception("connection reset by peer")
+        with pytest.raises(Exception, match="connection reset"):
+            svc.try_set_indexing_status("r1")
 
 
 class TestRouteWiring:

--- a/backend/tests/test_durable_repo_state.py
+++ b/backend/tests/test_durable_repo_state.py
@@ -1,0 +1,198 @@
+"""Durable repo-state v0.1 (#311): lazy re-clone + stuck-job recovery.
+
+Covers ensure_clone (warm no-op / cold re-clone / concurrency / no git_url) and the
+stuck-indexing recovery paths (timestamp stamping, steal-on-retry filter, startup sweep).
+"""
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import pytest
+
+from services.repo_manager import RepositoryManager, RepoCloneError
+
+
+def _make_manager(tmp_path) -> RepositoryManager:
+    """RepositoryManager with disk scan + Supabase stubbed, repos_dir pointed at a tmp dir."""
+    with patch.object(RepositoryManager, "_sync_existing_repos"), \
+         patch("services.repo_manager.get_supabase_service") as mock_get_db:
+        mock_get_db.return_value = MagicMock()
+        mgr = RepositoryManager()
+    mgr.repos_dir = Path(tmp_path)
+    return mgr
+
+
+class TestEnsureClone:
+    async def test_warm_path_does_not_clone(self, tmp_path):
+        """Clone already present -> stat only, no re-clone, no behavior change (AC4)."""
+        mgr = _make_manager(tmp_path)
+        repo_id = "repo-warm"
+        (mgr.repos_dir / repo_id / ".git").mkdir(parents=True)
+        repo = {"id": repo_id, "git_url": "https://example.com/x.git", "branch": "main"}
+
+        with patch.object(mgr, "_clone_into_place") as clone:
+            path = await mgr.ensure_clone(repo)
+
+        clone.assert_not_called()
+        assert path == str(mgr.repos_dir / repo_id)
+        assert repo["local_path"] == str(mgr.repos_dir / repo_id)
+
+    async def test_cold_path_reclones(self, tmp_path):
+        """Clone missing (redeploy) -> re-clone from git_url@branch (AC1)."""
+        mgr = _make_manager(tmp_path)
+        repo_id = "repo-cold"
+        repo = {"id": repo_id, "git_url": "https://example.com/x.git", "branch": "dev"}
+
+        def fake_clone(rid, url, branch, canonical):
+            (canonical / ".git").mkdir(parents=True)
+
+        with patch.object(mgr, "_clone_into_place", side_effect=fake_clone) as clone:
+            path = await mgr.ensure_clone(repo)
+
+        clone.assert_called_once()
+        rid, url, branch, _canonical = clone.call_args.args
+        assert (rid, url, branch) == (repo_id, "https://example.com/x.git", "dev")
+        assert (Path(path) / ".git").exists()
+        assert repo["local_path"] == str(mgr.repos_dir / repo_id)
+
+    async def test_missing_git_url_raises_actionable_503(self, tmp_path):
+        """No usable git_url -> actionable 503, not an opaque 500 or silent 404."""
+        mgr = _make_manager(tmp_path)
+        repo = {"id": "repo-nourl", "git_url": "unknown", "branch": "main"}
+        with pytest.raises(RepoCloneError) as exc:
+            await mgr.ensure_clone(repo)
+        assert exc.value.status_code == 503
+        assert exc.value.detail["error"] == "REPO_UNAVAILABLE"
+
+    async def test_clone_failure_raises_actionable_503(self, tmp_path):
+        """A failed clone (private repo / network) surfaces as 503, not a raw 500."""
+        mgr = _make_manager(tmp_path)
+        repo = {"id": "repo-fail", "git_url": "https://example.com/private.git", "branch": "main"}
+
+        def boom(rid, url, branch, canonical):
+            raise RuntimeError("authentication required")
+
+        with patch.object(mgr, "_clone_into_place", side_effect=boom):
+            with pytest.raises(RepoCloneError) as exc:
+                await mgr.ensure_clone(repo)
+        assert exc.value.status_code == 503
+
+    async def test_concurrent_callers_clone_once(self, tmp_path):
+        """Two simultaneous ops on the same missing repo clone exactly once (AC2)."""
+        mgr = _make_manager(tmp_path)
+        repo_id = "repo-race"
+        calls = {"n": 0}
+
+        def fake_clone(rid, url, branch, canonical):
+            calls["n"] += 1
+            time.sleep(0.05)  # widen the window so the second caller is forced to wait on the lock
+            (canonical / ".git").mkdir(parents=True)
+
+        repo_a = {"id": repo_id, "git_url": "https://example.com/x.git", "branch": "main"}
+        repo_b = {"id": repo_id, "git_url": "https://example.com/x.git", "branch": "main"}
+
+        with patch.object(mgr, "_clone_into_place", side_effect=fake_clone):
+            await asyncio.gather(mgr.ensure_clone(repo_a), mgr.ensure_clone(repo_b))
+
+        assert calls["n"] == 1
+
+
+class TestStuckJobRecovery:
+    def _service(self):
+        from services.supabase_service import SupabaseService
+        svc = SupabaseService()
+        svc.client = MagicMock()
+        return svc
+
+    def test_update_status_indexing_stamps_started_at(self):
+        """Transition to 'indexing' records when it started, for the reaper's clock."""
+        svc = self._service()
+        svc.update_repository_status("r1", "indexing")
+        updates = svc.client.table.return_value.update.call_args.args[0]
+        assert updates["status"] == "indexing"
+        assert "indexing_started_at" in updates
+
+    def test_update_status_non_indexing_does_not_stamp(self):
+        svc = self._service()
+        svc.update_repository_status("r1", "indexed")
+        updates = svc.client.table.return_value.update.call_args.args[0]
+        assert updates == {"status": "indexed"}
+
+    def test_try_set_indexing_steal_filter(self):
+        """Steal condition covers fresh-claim, stale, and legacy NULL-timestamp rows (AC5)."""
+        svc = self._service()
+        exec_result = MagicMock()
+        exec_result.data = [{"id": "r1"}]
+        svc.client.table.return_value.update.return_value.eq.return_value.or_.return_value.execute.return_value = exec_result
+
+        assert svc.try_set_indexing_status("r1") is True
+        or_arg = svc.client.table.return_value.update.return_value.eq.return_value.or_.call_args.args[0]
+        assert "status.neq.indexing" in or_arg
+        assert "indexing_started_at.is.null" in or_arg
+        assert "indexing_started_at.lt." in or_arg
+
+    def test_try_set_indexing_false_when_fresh_job_owns(self):
+        """A live, recently-started job is not stealable -> returns False."""
+        svc = self._service()
+        exec_result = MagicMock()
+        exec_result.data = []
+        svc.client.table.return_value.update.return_value.eq.return_value.or_.return_value.execute.return_value = exec_result
+        assert svc.try_set_indexing_status("r1") is False
+
+    def test_reset_stuck_jobs_resets_indexing_to_error(self):
+        """Startup sweep flips every 'indexing' row to 'error' and reports the count (AC6)."""
+        svc = self._service()
+        exec_result = MagicMock()
+        exec_result.data = [{"id": "a"}, {"id": "b"}]
+        svc.client.table.return_value.update.return_value.eq.return_value.execute.return_value = exec_result
+
+        count = svc.reset_stuck_indexing_jobs()
+        assert count == 2
+        assert svc.client.table.return_value.update.call_args.args[0] == {"status": "error"}
+        assert svc.client.table.return_value.update.return_value.eq.call_args.args == ("status", "indexing")
+
+    def test_update_status_falls_back_when_column_missing(self):
+        """If migration 003 isn't applied, the status update degrades to no-column instead of 500."""
+        svc = self._service()
+        chain = svc.client.table.return_value.update.return_value.eq.return_value
+        chain.execute.side_effect = [Exception("PGRST204 column indexing_started_at not found"), MagicMock()]
+
+        svc.update_repository_status("r1", "indexing")
+
+        calls = svc.client.table.return_value.update.call_args_list
+        assert len(calls) == 2
+        assert "indexing_started_at" in calls[0].args[0]   # first attempt includes the new column
+        assert calls[1].args[0] == {"status": "indexing"}  # retry drops it
+
+    def test_try_set_indexing_falls_back_to_basic_cas_when_column_missing(self):
+        """Steal path errors without the column -> fall back to the original atomic CAS."""
+        svc = self._service()
+        eq_chain = svc.client.table.return_value.update.return_value.eq.return_value
+        eq_chain.or_.return_value.execute.side_effect = Exception("PGRST204 column missing")
+        fallback = MagicMock()
+        fallback.data = [{"id": "r1"}]
+        eq_chain.neq.return_value.execute.return_value = fallback
+
+        assert svc.try_set_indexing_status("r1") is True
+        eq_chain.neq.assert_called_once_with("status", "indexing")
+
+
+class TestRouteWiring:
+    """Integration: a route actually invokes ensure_clone (guards against the guard being removed)."""
+
+    def test_dependency_route_triggers_ensure_clone(self, client):
+        repo = {
+            "id": "r-int", "git_url": "https://example.com/x.git", "branch": "main",
+            "local_path": "./repos/r-int", "include_paths": None,
+            "name": "x", "status": "indexed", "file_count": 0,
+        }
+        with patch("routes.analysis.get_repo_or_404", return_value=repo), \
+             patch("routes.analysis.repo_manager.ensure_clone", new=AsyncMock(return_value="./repos/r-int")) as ensure, \
+             patch("routes.analysis.dependency_analyzer.load_from_cache", return_value=None), \
+             patch("routes.analysis.dependency_analyzer.build_dependency_graph", return_value={"dependencies": {}, "metrics": {}}), \
+             patch("routes.analysis.dependency_analyzer.save_to_cache"):
+            resp = client.get("/api/v1/repos/r-int/dependencies?force=true")
+
+        assert resp.status_code == 200
+        ensure.assert_awaited_once()


### PR DESCRIPTION
## Summary

Repos stored on Railway's ephemeral disk vanished on every redeploy while Supabase still marked them `indexed`, so all file-based ops (graph, DNA, style, search context) 404'd until a manual re-index. This makes `local_path` a cache hint and lazily re-clones from the git remote on demand, and recovers indexing jobs left stuck in `indexing` when their process dies.

## Closes / implements

- Closes #311
- ADR: `oci/decisions/2026-06-08-durable-repo-state-v0.1.md`
- Branch: `fix/durable-repo-state-v0.1`
- Wave: pre-thesis (Tier 0 reliability)

## What changed

**Backend** (`backend/...`):
- `services/repo_manager.py` - new `ensure_clone(repo)` chokepoint: warm hit is a sub-ms stat; cache miss re-clones from `git_url`@`branch` via `asyncio.to_thread`, guarded by an in-process per-repo lock + clone-to-temp-then-atomic-rename. New `RepoCloneError` (503) for unrecoverable misses.
- `routes/analysis.py` - graph/impact/insights/style/DNA route through `ensure_clone` just-in-time (after the cache check; impact validates input first, then re-clones).
- `routes/repos.py` - directory listing, sync index, async index, and the legacy WebSocket index path all re-hydrate via `ensure_clone`.
- `services/supabase_service.py` - stamp `indexing_started_at` on every transition to `indexing`; `try_set_indexing_status` re-claims stale/legacy rows via an atomic PostgREST `.or_` CAS; new `reset_stuck_indexing_jobs()`. Both write paths degrade gracefully if migration 003 is not yet applied.
- `main.py` - startup sweep resets orphaned `indexing` rows on boot.
- `migrations/003_add_indexing_started_at.sql` - adds `indexing_started_at TIMESTAMPTZ` + partial index.

**Tests**:
- `tests/test_durable_repo_state.py` - 13 tests: ensure_clone warm/cold/concurrency/503, stuck-job stamping/steal/sweep/fallback, and a route-wiring integration test.

## ADR adherence

- [x] **Data model** matches ADR "Data model" (`indexing_started_at` column; clone is ephemeral cache)
- [x] **Consistency guarantee** matches ADR (`local_path` reframed as cache hint, git remote authoritative)
- [x] **Latency budget** honored - warm path is a `Path.exists()` stat (sub-ms); cold path is bounded by `git clone --depth 1` time and runs off the event loop. No p50/p95 harness exists yet (tracked in #313); no new hot-path latency added.
- [x] **Blast radius** is what the ADR predicted (only the scoped surfaces; no off-limits files)
- [x] **All acceptance criteria** checked in "How to test"
- [x] **Failure modes** guarded; private-repo note corrected to "pre-existing gap, not a regression" (tracked in #315)

## Pipeline

- [x] `/oci-pipeline` ran clean - BLOCKING: 0; MAJOR: 2 (both fixed - route integration test added; graceful migration fallback added)
- [ ] CodeRabbit comments addressed (pending PR)
- [ ] `/oci-defend` 7/7 passed (run after CI green)
- [x] All stack tests pass:
  - Backend: `cd backend && pytest tests/` - **405 passed**
  - Frontend: n/a - no frontend changes
  - MCP: n/a - no mcp-server changes

## How to test

1. Index a public repo, confirm graph/DNA work.
2. Simulate a redeploy: `rm -rf backend/repos/{repo_id}` (wipe the working tree, leave Supabase/Pinecone intact).
3. Call `GET /api/v1/repos/{repo_id}/dependencies` (or DNA/style/index).
4. Stuck job: set a repo's `status='indexing'` in Supabase, restart the backend.

Expected: step 3 re-clones from `git_url` and returns 200 with no manual re-index (first call slower, subsequent calls fast); step 4 - the startup sweep resets the row to `error` and the user can re-trigger indexing.

## Deployment notes

- [x] **No new env vars** required
- [ ] **DB migration REQUIRED** - run `backend/migrations/003_add_indexing_started_at.sql` in the Supabase SQL Editor **before deploying this code**. The code degrades gracefully if it's missing (no 500s), but stuck-job recovery stays off until the column exists.
- [x] **No off-limits files modified**
- [x] **No `mcp` package version change**
- [x] **No breaking change to `/api/v1/*` contracts** - status changes (500 to 503 on unrecoverable miss; 404 to re-clone on `/directories`) are handled generically by the MCP `_safe_error_message`; no URL/shape/field/auth change. Cross-stack contract check passed.

## Tradeoff annotation (Paired-Ship Protocol)

- We chose **lazy on-demand re-clone** over eager re-clone-all at startup because eager risks the 300s Railway healthcheck timeout on a cold container with many/large repos - the exact surface behind a prior silent prod outage (F-011) - and clones repos nobody queries this deploy.
- Latency tradeoff: the first access per repo after a redeploy pays the full clone cost (seconds to minutes); every access after is a sub-ms stat. We accept one slow request over a permanent 404.
- Consistency: strengthened (no permanent stuck-indexing state; clone re-hydrates from the authoritative remote).
- Operational: easier to debug (INFO log + `repos_recloned` metric on re-clone; WARN on sweep), and the single chokepoint is the seam for the deferred pro-tier (persistent volume) and private-repo support (#315) without touching call sites again.

## Risk and rollback

- **Symptom:** if `ensure_clone` were wrong, repo file-ops would 503 (clear, actionable) rather than silently serve stale or 500. Stuck-job sweep only ever touches rows already in `indexing`.
- **Blast radius:** the chokepoint fronts all file-based ops, but is purely additive on the warm path (existing behavior unchanged when the clone is present).
- **Rollback:** revert this PR. No data migration to undo (the new column is additive and nullable; leaving it is harmless).
- **Time-to-rollback:** < 5 min (revert + redeploy).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed recovery of stuck indexing jobs on system startup
  * Improved repository cloning with atomic operations and proper cleanup on failure

* **New Features**
  * Added automatic repository re-cloning when working tree is unavailable (e.g., after container redeployment)
  * Enhanced error handling for clone failures with actionable error messages
  * Prevents concurrent clone attempts for the same repository

* **Tests**
  * Added comprehensive test coverage for repository state durability and concurrent operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->