### PR TITLE
chore(deps): bump react-router-dom to ^7.15.0 (fixes 4 HIGH react-router CVEs)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -36,7 +36,7 @@
         "next-themes": "^0.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^7.12.0",
+        "react-router-dom": "^7.15.0",
         "react-syntax-highlighter": "^16.1.0",
         "sigma": "^3.0.2",
         "sonner": "^2.0.7",
@@ -884,9 +884,9 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
-    "react-router": ["react-router@7.13.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw=="],
+    "react-router": ["react-router@7.17.0", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ=="],
 
-    "react-router-dom": ["react-router-dom@7.13.0", "", { "dependencies": { "react-router": "7.13.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g=="],
+    "react-router-dom": ["react-router-dom@7.17.0", "", { "dependencies": { "react-router": "7.17.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.12.0",
+    "react-router-dom": "^7.15.0",
     "react-syntax-highlighter": "^16.1.0",
     "sigma": "^3.0.2",
     "sonner": "^2.0.7",


### PR DESCRIPTION
## Summary
Bumps `react-router-dom` (floor `^7.15.0`, resolves to 7.17.0) to clear 4 HIGH `react-router` CVEs that Trivy flags on every PR's Security Scan.

## CVEs fixed (all in transitive `react-router` 7.13.0)
- CVE-2026-33245 - XSS in unstable RSC redirect handling (fixed 7.13.2)
- CVE-2026-34077 - DoS via reflected user input (fixed 7.14.0)
- CVE-2026-42211 - turbo-stream arbitrary constructor invocation (fixed 7.14.2)
- CVE-2026-42342 - DoS via unbounded path expansion in `__manifest` (fixed 7.15.0)

## Changes
- `frontend/package.json`: `react-router-dom` `^7.12.0` to `^7.15.0`
- `frontend/bun.lock`: `react-router`/`react-router-dom` 7.13.0 to 7.17.0

## Validation
- `bun run typecheck` clean
- `bun run test` - 13 passed
- `bun run build` - succeeds

Dependency bump only, no code changes. Unblocks the Security Scan check on other open PRs (e.g. #316) once merged into main.