### PR TITLE
fix: bind uvicorn to Railway's dynamic $PORT (prod deploy healthcheck failure)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,13 +22,15 @@ COPY . .
 # Create repos directory for cloning
 RUN mkdir -p repos
 
-# Expose port
+# Expose the default port (informational; Railway injects its own $PORT at runtime)
 EXPOSE 8000
 
-# Health check
+# Health check hits whatever port the app bound to, so it tracks $PORT not a hardcoded 8000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health').read()" || exit 1
+    CMD python -c "import os,urllib.request; p=os.environ.get('PORT','8000'); urllib.request.urlopen('http://localhost:'+p+'/health').read()" || exit 1
 
-# Run with uvicorn (proxy-headers enabled for rate limiting behind reverse proxy)
-# Set FORWARDED_ALLOW_IPS env var in production to your proxy's IP range
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers"]
+# Bind Railway's dynamic $PORT (fallback 8000 for local/compose). The platform healthcheck
+# queries $PORT, so hardcoding 8000 here makes the deploy fail "service unavailable".
+# exec keeps uvicorn as PID 1 so it gets SIGTERM for graceful shutdown.
+# proxy-headers for rate limiting behind the reverse proxy (set FORWARDED_ALLOW_IPS in prod).
+CMD exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers


### PR DESCRIPTION
## Problem

Production backend (api.opencodeintel.com) was returning 502 `Application failed to respond` on every route. The browser surfaced it as a CORS error (no `Access-Control-Allow-Origin`), but the API was simply not reachable: no healthy Railway replica.

## Root cause

The Railway deploy was failing at the healthcheck step, not at boot. Deploy logs show the app starts fine (`Uvicorn running on http://0.0.0.0:8000`, `Application startup complete`), but `/health` returns "service unavailable" on all 11 attempts.

`backend/Dockerfile` hardcoded `--port 8000`. Railway assigns a **dynamic `$PORT`** and runs its platform healthcheck (`healthcheckPath: /health` in `railway.json`) against that port. Nothing listens there, so the healthcheck never passes and the deploy is rejected.

This was a latent bug: `healthcheckPath` was added to `railway.json` after the last good deploy (#293), so #293 served fine on 8000 with no healthcheck enforcing reachability. Every deploy since (#316, #318) hit this and failed silently for days; prod only stayed up on the stale #293 image until that replica was replaced.

## Fix

Bind uvicorn to `${PORT:-8000}` (fallback preserves local/docker-compose), and make the internal Docker healthcheck read the same port. `exec` keeps uvicorn as PID 1 for graceful SIGTERM shutdown.

```dockerfile
CMD exec uvicorn main:app --host 0.0.0.0 --port ${PORT:-8000} --proxy-headers
```

## Note for reviewer / on merge

This fix unblocks the deploy pipeline, so merging it will deploy the backend changes from #316 (durable repo-state) and #318 (eval harness) to prod **for the first time** — they were merged to main but never actually shipped because of this bug. Both passed CI/CodeRabbit; flagging so the first green deploy is expected to carry that code.

## Testing

- `${PORT:-8000}` expansion verified (set -> dynamic port, unset -> 8000).
- Real validation is the next Railway deploy's healthcheck passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend container configuration to support dynamic port assignment, enabling the service to adapt to hosting platforms that dynamically allocate ports at runtime. This ensures reliable operation across different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->