### PR TITLE
fix: give the MCP service its own railway.json (it was building the backend Dockerfile)

### DIFF
--- a/mcp-server/railway.json
+++ b/mcp-server/railway.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "DOCKERFILE",
-    "dockerfilePath": "mcp-server/Dockerfile",
-    "buildContext": "mcp-server"
+    "builder": "DOCKERFILE"
   },
   "deploy": {
     "restartPolicyType": "ON_FAILURE",

--- a/mcp-server/railway.json
+++ b/mcp-server/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "mcp-server/Dockerfile",
+    "buildContext": "mcp-server"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10,
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 300
+  }
+}


### PR DESCRIPTION
## Problem

The MCP service (`mcp.opencodeintel.com`) has been failing every deploy since #296 (~2 months) and is frozen on that stale image. Deploy logs show:

```
Error loading ASGI app. Could not import module "main".
```

repeated until all 11 healthcheck attempts fail with "service unavailable".

## Root cause

There is a single repo-root `railway.json` that is **backend-specific**:

```json
"build": { "dockerfilePath": "backend/Dockerfile", "buildContext": "backend" },
"deploy": { "healthcheckPath": "/health", ... }
```

Railway feeds this config to **both** services by default. The backend service reads it correctly. The MCP service inherits it and builds `backend/Dockerfile`, whose `CMD` is `uvicorn main:app` -- but `mcp-server/` has no `main.py`, only `server.py`. So uvicorn crashes at boot on every MCP deploy.

The MCP code itself is fine: `mcp-server/server.py` reads `$PORT` via `config.py` and serves a public `/health` route. The only problem is *which Dockerfile Railway builds for that service*.

## Fix

Stop the two services from sharing one backend-shaped config. Add a dedicated `mcp-server/railway.json` that builds `mcp-server/Dockerfile` with its own `/health` healthcheck. The backend service keeps reading the repo-root `railway.json` unchanged (it was just restored in #319; not touching it).

Deliberately **not** doing what Railway's auto-diagnosis suggested (stripping `dockerfilePath` from the root `railway.json`) -- that would remove the backend's build + healthcheck config and risk re-breaking the service #319 just fixed.

## Activation (required, manual)

This file is inert until the MCP service is pointed at it. In the Railway dashboard:
**MCP service (`marvelous-endurance`) -> Settings -> Config-as-code file path -> `mcp-server/railway.json`**, then redeploy. The backend service is left on the repo-root `railway.json`.

## Testing

- Confirmed `mcp-server/Dockerfile` runs `python server.py` (not uvicorn main:app) and its healthcheck already uses `${PORT:-8080}`.
- Confirmed `server.py` binds `$PORT` and registers a public `/health` route.
- Real validation: the next MCP deploy after the config-path change should pass healthcheck on `$PORT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured MCP server deployment infrastructure with automated health monitoring and failure recovery mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->