### PR TITLE
fix: bump ws to 8.21.0 via override (CVE-2026-48779) (#326)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -67,6 +67,9 @@
       },
     },
   },
+  "overrides": {
+    "ws": "^8.21.0",
+  },
   "packages": {
     "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
 
@@ -1024,7 +1027,7 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,5 +73,8 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.0",
     "typescript-eslint": "^8.0.0"
+  },
+  "overrides": {
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary

Forces `ws` to `8.21.0` across the dependency tree via a package.json `overrides`, clearing **CVE-2026-48779** (HIGH, memory-exhaustion DoS) that was failing the required Trivy `Security Scan` on every PR.

## Closes / implements

- Closes #326
- ADR: n/a - under ADR threshold (single dependency security bump)
- Branch: `fix/bump-ws-cve-2026-48779`

## What changed

**Frontend** (`frontend/...`):
- `package.json` - add `overrides: { "ws": "^8.21.0" }` to force the patched version across the whole tree.
- `bun.lock` - `ws` resolves `8.19.0 -> 8.21.0`; no nested `8.19.0` remains.

## Why the override (not `bun update ws`)

`ws` is transitive only (`@supabase/realtime-js -> ws@^8.18.2`, `happy-dom -> ws@^8.18.3`). `bun update ws` added `ws` as a direct dep at 8.21.0 but left both transitive consumers pinned at the vulnerable `8.19.0`. An `overrides` entry is the correct mechanism: it rewrites every `ws` resolution in the tree. Verified: `grep ws@8.19.0 bun.lock` returns nothing after the change.

## How to test

1. `cd frontend && bun install`
2. `grep -E 'ws@8\.' bun.lock` - expect only `ws@8.21.0` (and `@types/ws`, type defs, unrelated)
3. `bun run typecheck && bun run test && bun run build`

Expected: no `ws@8.19.0` anywhere; typecheck clean, 13 tests pass, build succeeds. Trivy Security Scan goes green.

## Deployment notes

- [x] **No new env vars**
- [x] **No DB migration**
- [x] **No off-limits files modified** (this is `bun.lock`, not the off-limits `bun.lockb`)
- [x] **No runtime API change** (patch-level WebSocket lib bump, same 8.x major)

## Risk and rollback

- **Symptom:** if a `ws` 8.21.0 behavior change regressed the Supabase realtime WebSocket (indexing-progress events), clients would see WS reconnect issues.
- **Blast radius:** Supabase realtime channel (indexing progress) + happy-dom test env. Low: same 8.x major, patch+minor bump only.
- **Rollback:** revert this PR. Lockfile-only, no migration.
- **Time-to-rollback:** < 5 min.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency configuration to enforce a specific version resolution for the `ws` library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->